### PR TITLE
Change trace context fields name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.1] - 2024-02-25
+
+### Changed
+
+- Change trace context fields name according to
+[Trace Context in non-OTLP Log Formats](https://opentelemetry.io/docs/specs/otel/compatibility/logging_trace_context/) (#22).
+
 ## [0.2.0] - 2024-02-25
 
 ### Add

--- a/gcp/handler.go
+++ b/gcp/handler.go
@@ -26,9 +26,10 @@ import (
 	"strings"
 )
 
-// Keys for [W3C Trace Context] attributes.
+// Keys for [W3C Trace Context] attributes by following [Trace Context in non-OTLP Log Formats].
 //
 // [W3C Trace Context]: https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+// [Trace Context in non-OTLP Log Formats]: https://www.w3.org/TR/trace-context/#trace-id
 const (
 	// TraceKey is the key used by the [ID of the whole trace] forest and is used to uniquely
 	// identify a distributed trace through a system. It is represented as a 16-byte array,
@@ -36,18 +37,18 @@ const (
 	// All bytes as zero (00000000000000000000000000000000) is considered an invalid value.
 	//
 	// [ID of the whole trace]: https://www.w3.org/TR/trace-context/#trace-id
-	TraceKey = "trace-id"
+	TraceKey = "trace_id"
 	// SpanKey is the key used by the [ID of this request] as known by the caller.
 	// It is represented as an 8-byte array, for example, 00f067aa0ba902b7.
 	// All bytes as zero (0000000000000000) is considered an invalid value.
 	//
 	// [ID of this request]: https://www.w3.org/TR/trace-context/#parent-id
-	SpanKey = "span-id"
+	SpanKey = "span_id"
 	// TraceFlagsKey is the key used by an 8-bit field that controls [tracing flags]
 	// such as sampling, trace level, etc.
 	//
 	// [tracing flags]: https://www.w3.org/TR/trace-context/#trace-flags
-	TraceFlagsKey = "trace-flags"
+	TraceFlagsKey = "trace_flags"
 )
 
 // New creates a new Handler with the given Option(s).
@@ -206,7 +207,7 @@ func (h logHandler) Handle(ctx context.Context, record slog.Record) error { //no
 	if h.contextProvider != nil {
 		var found bool
 		record.Attrs(func(attr slog.Attr) bool {
-			if attr.Key == "trace-id" {
+			if attr.Key == TraceKey {
 				found = true
 
 				return false

--- a/gcp/handler_test.go
+++ b/gcp/handler_test.go
@@ -34,9 +34,9 @@ func TestHandler(t *testing.T) {
 			if handler.Enabled(ctx, slog.LevelInfo) {
 				assert.NoError(t, handler.WithAttrs([]slog.Attr{slog.String("a", "A")}).
 					Handle(ctx, record(slog.LevelInfo, "info",
-						"trace-id", "4bf92f3577b34da6a3ce929d0e0e4736",
-						"span-id", "00f067aa0ba902b7",
-						"trace-flags", "01"),
+						"trace_id", "4bf92f3577b34da6a3ce929d0e0e4736",
+						"span_id", "00f067aa0ba902b7",
+						"trace_flags", "01"),
 					))
 			}
 			gHandler := handler.WithGroup("g")
@@ -101,7 +101,7 @@ func testcases() []struct {
 	}{
 		{
 			description: "default",
-			expected: `{"timestamp":{"seconds":100,"nanos":1000},"severity":"INFO","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":36},"message":"info","a":"A","trace-id":"4bf92f3577b34da6a3ce929d0e0e4736","span-id":"00f067aa0ba902b7","trace-flags":"01"}
+			expected: `{"timestamp":{"seconds":100,"nanos":1000},"severity":"INFO","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":36},"message":"info","a":"A","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01"}
 {"timestamp":{"seconds":100,"nanos":1000},"severity":"WARNING","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":45},"message":"warn","g":{"b":"B","a":"A"}}
 {"timestamp":{"seconds":100,"nanos":1000},"severity":"ERROR","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":53},"message":"error","g":{"h":{"b":"B"}}}
 `,
@@ -121,7 +121,7 @@ func testcases() []struct {
 				gcp.WithErrorReporting("test", "dev"),
 			},
 			err: errors.New("an error"),
-			expected: `{"timestamp":{"seconds":100,"nanos":1000},"severity":"INFO","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":36},"message":"info","a":"A","trace-id":"4bf92f3577b34da6a3ce929d0e0e4736","span-id":"00f067aa0ba902b7","trace-flags":"01"}
+			expected: `{"timestamp":{"seconds":100,"nanos":1000},"severity":"INFO","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":36},"message":"info","a":"A","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01"}
 {"timestamp":{"seconds":100,"nanos":1000},"severity":"WARNING","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":45},"message":"warn","g":{"b":"B","a":"A"}}
 {"timestamp":{"seconds":100,"nanos":1000},"severity":"ERROR","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":53},"message":"error","context":{"reportLocation":{"filePath":"/handler_test.go","lineNumber":53,"functionName":"github.com/nil-go/sloth/gcp_test.TestHandler.func1"}},"serviceContext":{"service":"test","version":"dev"},"stack_trace":"error\n\n\ngithub.com/nil-go/sloth/gcp_test.TestHandler.func1()\n\t/handler_test.go:53"g":{"h":{"b":"B","error":"an error"}}}
 `,
@@ -138,7 +138,7 @@ func testcases() []struct {
 				}),
 			},
 			err: errors.New("an error"),
-			expected: `{"timestamp":{"seconds":100,"nanos":1000},"severity":"INFO","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":36},"message":"info","a":"A","trace-id":"4bf92f3577b34da6a3ce929d0e0e4736","span-id":"00f067aa0ba902b7","trace-flags":"01"}
+			expected: `{"timestamp":{"seconds":100,"nanos":1000},"severity":"INFO","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":36},"message":"info","a":"A","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01"}
 {"timestamp":{"seconds":100,"nanos":1000},"severity":"WARNING","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":45},"message":"warn","g":{"b":"B","a":"A"}}
 {"timestamp":{"seconds":100,"nanos":1000},"severity":"ERROR","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":53},"message":"error","context":{"reportLocation":{"filePath":"/handler_test.go","lineNumber":53,"functionName":"github.com/nil-go/sloth/gcp_test.TestHandler.func1"}},"serviceContext":{"service":"test","version":"dev"},"stack_trace":"error\n\n\ngithub.com/nil-go/sloth/gcp_test.testcases.func1()\n\t/handler_test.go:135"g":{"h":{"b":"B","error":"an error"}}}
 `,
@@ -149,7 +149,7 @@ func testcases() []struct {
 				gcp.WithErrorReporting("test", "dev"),
 			},
 			err: stackError{errors.New("an error")},
-			expected: `{"timestamp":{"seconds":100,"nanos":1000},"severity":"INFO","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":36},"message":"info","a":"A","trace-id":"4bf92f3577b34da6a3ce929d0e0e4736","span-id":"00f067aa0ba902b7","trace-flags":"01"}
+			expected: `{"timestamp":{"seconds":100,"nanos":1000},"severity":"INFO","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":36},"message":"info","a":"A","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01"}
 {"timestamp":{"seconds":100,"nanos":1000},"severity":"WARNING","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":45},"message":"warn","g":{"b":"B","a":"A"}}
 {"timestamp":{"seconds":100,"nanos":1000},"severity":"ERROR","logging.googleapis.com/sourceLocation":{"function":"github.com/nil-go/sloth/gcp_test.TestHandler.func1","file":"/handler_test.go","line":53},"message":"error","context":{"reportLocation":{"filePath":"/handler_test.go","lineNumber":53,"functionName":"github.com/nil-go/sloth/gcp_test.TestHandler.func1"}},"serviceContext":{"service":"test","version":"dev"},"stack_trace":"error\n\n\ngithub.com/nil-go/sloth/gcp_test.stackError.Callers()\n\t/handler_test.go:74"g":{"h":{"b":"B","error":"an error"}}}
 `,

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/nil-go/sloth
 
 go 1.21
+
+retract [v0.1.0, v0.2.0] // wrong trace context key

--- a/otel/go.mod
+++ b/otel/go.mod
@@ -6,3 +6,5 @@ require (
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 )
+
+retract v0.2.0 // wrong trace context key

--- a/otel/handler.go
+++ b/otel/handler.go
@@ -20,9 +20,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// Keys for [W3C Trace Context] attributes.
+// Keys for [W3C Trace Context] attributes by following [Trace Context in non-OTLP Log Formats].
 //
 // [W3C Trace Context]: https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+// [Trace Context in non-OTLP Log Formats]: https://www.w3.org/TR/trace-context/#trace-id
 const (
 	// TraceKey is the key used by the [ID of the whole trace] forest and is used to uniquely
 	// identify a distributed trace through a system. It is represented as a 16-byte array,
@@ -30,18 +31,18 @@ const (
 	// All bytes as zero (00000000000000000000000000000000) is considered an invalid value.
 	//
 	// [ID of the whole trace]: https://www.w3.org/TR/trace-context/#trace-id
-	TraceKey = "trace-id"
+	TraceKey = "trace_id"
 	// SpanKey is the key used by the [ID of this request] as known by the caller.
 	// It is represented as an 8-byte array, for example, 00f067aa0ba902b7.
 	// All bytes as zero (0000000000000000) is considered an invalid value.
 	//
 	// [ID of this request]: https://www.w3.org/TR/trace-context/#parent-id
-	SpanKey = "span-id"
+	SpanKey = "span_id"
 	// TraceFlagsKey is the key used by an 8-bit field that controls [tracing flags]
 	// such as sampling, trace level, etc.
 	//
 	// [tracing flags]: https://www.w3.org/TR/trace-context/#trace-flags
-	TraceFlagsKey = "trace-flags"
+	TraceFlagsKey = "trace_flags"
 )
 
 // Handler correlates log records with Open Telemetry spans.

--- a/otel/handler_test.go
+++ b/otel/handler_test.go
@@ -123,9 +123,9 @@ level=INFO msg=msg3 g.h.error="an error"
 				SpanID:     [8]byte{0, 240, 103, 170, 11, 169, 2, 183},
 				TraceFlags: trace.TraceFlags(0),
 			}),
-			expectedLog: `level=INFO msg=msg1 a=A trace-id=4bf92f3577b34da6a3ce929d0e0e4736 span-id=00f067aa0ba902b7 trace-flags=00
-level=INFO msg=msg2 trace-id=4bf92f3577b34da6a3ce929d0e0e4736 span-id=00f067aa0ba902b7 trace-flags=00 g.b=B
-level=INFO msg=msg3 trace-id=4bf92f3577b34da6a3ce929d0e0e4736 span-id=00f067aa0ba902b7 trace-flags=00 g.h.error="an error"
+			expectedLog: `level=INFO msg=msg1 a=A trace_id=4bf92f3577b34da6a3ce929d0e0e4736 span_id=00f067aa0ba902b7 trace_flags=00
+level=INFO msg=msg2 trace_id=4bf92f3577b34da6a3ce929d0e0e4736 span_id=00f067aa0ba902b7 trace_flags=00 g.b=B
+level=INFO msg=msg3 trace_id=4bf92f3577b34da6a3ce929d0e0e4736 span_id=00f067aa0ba902b7 trace_flags=00 g.h.error="an error"
 `,
 		},
 		{

--- a/rate/handler_test.go
+++ b/rate/handler_test.go
@@ -129,7 +129,7 @@ func TestHandler_race(t *testing.T) {
 
 			<-start
 			logger.Log(ctx, slog.LevelInfo, "msg")
-			time.Sleep(time.Second)
+			time.Sleep(2 * time.Second)
 			logger.Log(ctx, slog.LevelInfo, "msg")
 		}()
 	}


### PR DESCRIPTION
according to
[Trace Context in non-OTLP Log Formats](https://opentelemetry.io/docs/specs/otel/compatibility/logging_trace_context/)